### PR TITLE
Critical fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install beluga-ml
 Import beluga into your project
 
 ```py
-import beluga-ml
+import beluga
 ```
 
 

--- a/beluga/__init__.py
+++ b/beluga/__init__.py
@@ -1,0 +1,1 @@
+from . import metrics, helpers

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Data Science with Daniel",
     url="https://github.com/datasciencewithdaniel/beluga",
-    license="MIT",
+    license="GPL-3.0",
     install_requires=["numpy"],
     setup_requires=["pytest-runner", "pytest-cov"],
     tests_require=["pytest"],


### PR DESCRIPTION
When I install **beluga** library via **pip** and call any method it throws an AttributeError *( issue #18 )*
I added following line to **\_\_init\_\_.py** file for library to work properly and error is gone:
```py
from . import metrics, helpers
```
(maybe **helpers** are redundant here)

Also changed 'import beluga-ml' line in README because it is Invalid Syntax
Then I fixed license mismatch in **setup.py** *( issue #19 )*
